### PR TITLE
The number of logical CPUs can be now set using --cpus flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ Flags:
                           --help-man).
   -d, --duration=10s      Load test duration.
   -c, --connections=50    Maximum number of concurrent connections.
+      --cpus              Maximum number of logical CPUs that can be utilised.
+                          Defaults to the number of available CPU threads (or 
+                          the GOMAXPROCS env variable).
   -t, --timeout=200ms     HTTP client timeout.
   -m, --mode="reqlog"     Statistics collection mode: reqlog (logs each request)
                           or hist (stores histogram of completed requests

--- a/args.go
+++ b/args.go
@@ -2,8 +2,6 @@ package main
 
 import (
 	"os"
-	"runtime"
-	"strconv"
 
 	"github.com/kffl/gocannon/common"
 	"gopkg.in/alecthomas/kingpin.v2"
@@ -46,8 +44,8 @@ func parseArgs() (common.Config, error) {
 			PlaceHolder("file.csv").
 			Short('o').
 			String(),
-		CPUs: app.Flag("cpus", "Maximum number of logical CPUs").
-			Default(strconv.Itoa(runtime.NumCPU())).
+		CPUs: app.Flag("cpus", "Maximum number of logical CPUs that can be utilised. Defaults to the number of available CPU threads (or the GOMAXPROCS env variable).").
+			Default("0").
 			Int(),
 		Interval: app.Flag("interval", "Interval for statistics calculation (reqlog mode).").
 			Default("250ms").

--- a/args.go
+++ b/args.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"os"
+	"runtime"
+	"strconv"
 
 	"github.com/kffl/gocannon/common"
 	"gopkg.in/alecthomas/kingpin.v2"
@@ -44,6 +46,9 @@ func parseArgs() (common.Config, error) {
 			PlaceHolder("file.csv").
 			Short('o').
 			String(),
+		CPUs: app.Flag("cpus", "Maximum number of logical CPUs").
+			Default(strconv.Itoa(runtime.NumCPU())).
+			Int(),
 		Interval: app.Flag("interval", "Interval for statistics calculation (reqlog mode).").
 			Default("250ms").
 			Short('i').

--- a/common/config.go
+++ b/common/config.go
@@ -11,6 +11,7 @@ type Config struct {
 	OutputFile  *string
 	Interval    *time.Duration
 	Preallocate *int
+	CPUs        *int
 	Method      *string
 	Body        *RawRequestBody
 	Headers     *RequestHeaders

--- a/gocannon.go
+++ b/gocannon.go
@@ -61,7 +61,10 @@ func NewGocannon(cfg common.Config) (Gocannon, error) {
 func (g Gocannon) Run() (TestResults, error) {
 
 	n := *g.cfg.Connections
-	runtime.GOMAXPROCS(*g.cfg.CPUs)
+
+	if g.cfg.CPUs != nil {
+		runtime.GOMAXPROCS(*g.cfg.CPUs)
+	}
 
 	var wg sync.WaitGroup
 

--- a/gocannon.go
+++ b/gocannon.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"sync"
-	"runtime"
 
 	"github.com/kffl/gocannon/common"
 	"github.com/valyala/fasthttp"
@@ -61,10 +60,6 @@ func NewGocannon(cfg common.Config) (Gocannon, error) {
 func (g Gocannon) Run() (TestResults, error) {
 
 	n := *g.cfg.Connections
-
-	if g.cfg.CPUs != nil {
-		runtime.GOMAXPROCS(*g.cfg.CPUs)
-	}
 
 	var wg sync.WaitGroup
 

--- a/gocannon.go
+++ b/gocannon.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"sync"
+	"runtime"
 
 	"github.com/kffl/gocannon/common"
 	"github.com/valyala/fasthttp"
@@ -60,6 +61,7 @@ func NewGocannon(cfg common.Config) (Gocannon, error) {
 func (g Gocannon) Run() (TestResults, error) {
 
 	n := *g.cfg.Connections
+	runtime.GOMAXPROCS(*g.cfg.CPUs)
 
 	var wg sync.WaitGroup
 

--- a/integration_test.go
+++ b/integration_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"math"
 	"os/exec"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -96,6 +97,7 @@ func TestGocannon(t *testing.T) {
 func TestGocannonDefaultValues(t *testing.T) {
 	duration := time.Second * 1
 	connections := 50
+	cpus := runtime.NumCPU()
 	timeout := time.Millisecond * 200
 	mode := "reqlog"
 	outputFile := ""
@@ -112,6 +114,7 @@ func TestGocannonDefaultValues(t *testing.T) {
 	cfg := common.Config{
 		Duration:    &duration,
 		Connections: &connections,
+		CPUs:				 &cpus,
 		Timeout:     &timeout,
 		Mode:        &mode,
 		OutputFile:  &outputFile,
@@ -145,6 +148,7 @@ func TestGocanonWithPlugin(t *testing.T) {
 
 	duration := time.Second * 1
 	connections := 50
+	cpus := runtime.NumCPU()
 	timeout := time.Millisecond * 200
 	mode := "hist"
 	outputFile := ""
@@ -161,6 +165,7 @@ func TestGocanonWithPlugin(t *testing.T) {
 	cfg := common.Config{
 		Duration:    &duration,
 		Connections: &connections,
+		CPUs:				 &cpus,
 		Timeout:     &timeout,
 		Mode:        &mode,
 		OutputFile:  &outputFile,

--- a/integration_test.go
+++ b/integration_test.go
@@ -114,7 +114,7 @@ func TestGocannonDefaultValues(t *testing.T) {
 	cfg := common.Config{
 		Duration:    &duration,
 		Connections: &connections,
-		CPUs:				 &cpus,
+		CPUs:        &cpus,
 		Timeout:     &timeout,
 		Mode:        &mode,
 		OutputFile:  &outputFile,
@@ -165,7 +165,7 @@ func TestGocanonWithPlugin(t *testing.T) {
 	cfg := common.Config{
 		Duration:    &duration,
 		Connections: &connections,
-		CPUs:				 &cpus,
+		CPUs:        &cpus,
 		Timeout:     &timeout,
 		Mode:        &mode,
 		OutputFile:  &outputFile,

--- a/main.go
+++ b/main.go
@@ -1,12 +1,17 @@
 package main
 
-import "fmt"
+import (
+	"fmt"
+	"runtime"
+)
 
 func main() {
 	config, err := parseArgs()
 	if err != nil {
 		exitWithError(err)
 	}
+
+	runtime.GOMAXPROCS(*config.CPUs)
 
 	if *config.Format == "default" {
 		printHeader(config)

--- a/print.go
+++ b/print.go
@@ -7,7 +7,7 @@ import (
 )
 
 func printHeader(cfg common.Config) {
-	fmt.Printf("Attacking %s with %d connections over %s\n", *cfg.Target, *cfg.Connections, *cfg.Duration)
+	fmt.Printf("Attacking %s with %d connections over %s using %d CPUs\n", *cfg.Target, *cfg.Connections, *cfg.Duration, *cfg.CPUs)
 }
 
 func printSummary(s TestResults) {

--- a/print.go
+++ b/print.go
@@ -2,12 +2,13 @@ package main
 
 import (
 	"fmt"
+	"runtime"
 
 	"github.com/kffl/gocannon/common"
 )
 
 func printHeader(cfg common.Config) {
-	fmt.Printf("Attacking %s with %d connections over %s using %d CPUs\n", *cfg.Target, *cfg.Connections, *cfg.Duration, *cfg.CPUs)
+	fmt.Printf("Attacking %s with %d connections over %s using %d CPUs\n", *cfg.Target, *cfg.Connections, *cfg.Duration, runtime.GOMAXPROCS(0))
 }
 
 func printSummary(s TestResults) {


### PR DESCRIPTION
This pull request adds the feature mentioned in issue #20 